### PR TITLE
fix links to open where they should

### DIFF
--- a/src/ch_YVIPModule1.asc
+++ b/src/ch_YVIPModule1.asc
@@ -87,7 +87,7 @@ So how do you get started?   Let’s take a look at a short song in EarSketch th
 ****
 1. If you do not have an account in EarSketch click the
 *Create/Reset Account* in the upper right corner to create your
-account to login. If you need help, click     https://earsketch.gatech.edu/yvip/Get-Started-in-EarSketch.pdf[Instructions for creating an account]
+account to login. If you need help, click     https://earsketch.gatech.edu/yvip/Get-Started-in-EarSketch.pdf[Instructions for creating an account^]
 if you need help logging into EarSketch
 2. If you already have an EarSketch account, login to your account.
 3. In the box below, click the blue clipboard icon to copy this text into the code editor
@@ -196,18 +196,18 @@ Watch this https://earsketch.gatech.edu/yvip/Video01-Account-Creation-Opening-Sc
 
 Look at the YVIP Sample Script in the code editor.  You will notice the script is numbered; we are going to start by looking at our first five lines.
 
-You may notice immediately that in front of the text in these lines are the # sign.  These lines are not trending hashtags on twitter, but *comments*.  The computer does not execute code that is preceded by the *#*.
+You may notice immediately that in front of the text in these lines are the # sign.  These lines are not trending hashtags on twitter, but *comments*.  The computer does not execute code that is preceded by the `#`.
 
 In this code, there are comments about the purpose of the code, the source of some of the music in the code, and the author of the code.  Always put the # sign in front of your comments.  You can also use the # sign to see how your script functions with or without some lines.
 
 Look at your sample script.  What are comments being used for in your code?  What information do they tell you about about your code?
 
 ****
-*Student Activity: Using the # sign*
+*Student Activity: Using the `#` sign*
 
 1. Run your script by clicking the green run button on the top right of your code editor
 2. Click play at the top of the EarSketch DAW to listen to your script.
-3. 	Go to Line 23-28 in your script editor . Place a *#* in front of the some of the `fitMedia()` lines
+3. 	Go to Line 23-28 in your script editor . Place a `#` in front of the some of the `fitMedia()` lines
 4. 	Run your script again.
 5. 	What happens? What is different about your song?
 ****

--- a/src/ch_YVIPModule2.asc
+++ b/src/ch_YVIPModule2.asc
@@ -66,7 +66,7 @@ If you would like to learn more about these different types of racism, click the
 * Institutional: https://earsketch.gatech.edu/yvip/Example-Media.pdf[Media^]
 * Interpersonal and Institutional: https://earsketch.gatech.edu/yvip/Example-Police-Brutality.pdf[Police Brutality^]
 * Interpersonal: https://earsketch.gatech.edu/yvip/Example-Hate-Crime.pdf[Hate Crimes^]
-* Structural: https://earsketch.gatech.edu/yvip/Example-Bank.pdf[Bank]
+* Structural: https://earsketch.gatech.edu/yvip/Example-Bank.pdf[Bank^]
 ****
 
 Think about how you could incorporate messages about the different types of racism in your song.  Remember, it’s not just words that tell a message but the instrumentals too.  You can use contrasting sounds, volume, and different beats to communicate a message in your song.
@@ -100,13 +100,11 @@ Fill your DJ code name as the author and you are ready to get started coding and
 [source,python]
 
 ----
-from earsketch import *
-
 #comments
-#	author:
-#	description:
+#author:
+#description:
 #
-
+#
 from earsketch import *
 #setup
 init()
@@ -134,7 +132,7 @@ and from over 300 different instrument samples. In addition to https://en.wikipe
 from recording artists and sound engineers such as https://en.wikipedia.org/wiki/Ciara[Ciara^], https://en.wikipedia.org/wiki/Common_(rapper)[Common^], https://en.wikipedia.org/wiki/Richard_Devine[Richard Devine^], and
 https://en.wikipedia.org/wiki/Young_Guru[Young Guru^]. _(Click on the artists’ name to learn more about their music)_
 
-Our first step is create a #SOUNDBANK with all our favorite sounds that we will use during our song.  Your #SOUNDBANK will be like a closet that holdsfavorite sound clips.  You will get to go into that closet and place those sounds in your song when and where you want them. Most songs include at least one sound from 5 main categories:
+Our first step is create a `#SOUNDBANK` with all our favorite sounds that we will use during our song.  Your `#SOUNDBANK` will be like a closet that holdsfavorite sound clips.  You will get to go into that closet and place those sounds in your song when and where you want them. Most songs include at least one sound from 5 main categories:
 
 * SteadyBeat - drum beats and percussion loops
 * Bass - Deep and low sounding instruments
@@ -185,7 +183,7 @@ Look at your `#SOUNDBANK` in your code editor.  It’s time to assign these clip
 1. Assign the  soundclip a variable name or nickname  (usually the name connects to the sound, just like a nickname is connected to your full name)
 2. Use the assignment operator =  to assign your variable a value.  Ex. `drum=ENTREP_BEAT_DRUMBEAT`
 3. Complete for each sound clip in your `#SOUNDBANK`
-3. https://earsketch.gatech.edu/earsketch2/#?curriculum=1-2-4&language=python[Click here^] to learn more about variables
+3. <<ch_2#variables,Click here>> to learn more about variables
  and review your sample script from Module 1 to see an example of a `#SOUNDBANK`.
 
 ***
@@ -211,9 +209,9 @@ Ex. `fitMedia(RD_UK_HOUSE_MAINBEAT_8,1,1,5)`
 ***
 *_Student Activity: Adding Sound Clips_*
 
-_You can now add sound clips to code #verse 1 of your song._
+_You can now add sound clips to code `#verse 1` of your song._
 
-1. Find the  #verse1 in your script. Click enter to type on the next line
+1. Find the  `#verse1` in your script. Click enter to type on the next line
 2. Type `fitMedia()` in your code editor.
 3. Choose a sound from your `#SOUNDBANK` and enter the variable name as your first argument.  Place a comma after the variable name.
 4. Enter “*1*” as your trackNumber. Place a comma after the track number.
@@ -226,7 +224,7 @@ _You can now add sound clips to code #verse 1 of your song._
 ***
 
 Remember to check that you have commas between each argument and close your parentheses.
-Run and play your song often to hear your beats.  If you need additional support, check out the EarSketch chapter on https://earsketch.gatech.edu/earsketch2#?curriculum=1-1-9&language=python[Composing in EarSketch^] .  You can review lines 23-28 of your sample script.
+Run and play your song often to hear your beats.  If you need additional support, check out the EarSketch chapter on <<ch_1#composinginearsketch,Composing in EarSketch>>.  You can review lines 23-28 of your sample script.
 
 
 

--- a/src/ch_YVIP_FinalSubmission.asc
+++ b/src/ch_YVIP_FinalSubmission.asc
@@ -14,16 +14,16 @@ your “voice” (or includes a message). Think about the call to action and how
 |======================================
 | *Topic* | *Description* | *Resources*
 | Custom Functions    |Write your own functions to define sections of your song
-|link:https://earsketch.gatech.edu/earsketch2#?curriculum=2-1-0&language=python[9.1 Musical Form and Custom Functions^]
- link:https://earsketch.gatech.edu/earsketch2#?curriculum=2-1-0&language=python[Custom Functions Video^]
+|<<ch_9#,Musical Form and Custom Functions>>
+ <<ch_9#customfunctions,Custom Functions Video>>
 |   Uploading Sounds     |If you want to add your “actual voice to the song by singing or uploading lyrics.  You may want to add some community sounds or other sounds that are not in the EarSketch library.   By choosing uploading sounds from the sound browser, you  will have the options to Upload a New Sound, do a quick record or find a clip on Freesound.
 
-|link:https://earsketch.gatech.edu/earsketch2/#?curriculum=2-2-0&language=python[Uploading Sounds^]
+|<<ch_10#,Uploading Sounds>>
 
-link:https://earsketch.gatech.edu/yvip/Uploading-Sounds.pdf[Tutorials^]|setEffect() |You will learn how to adjust track volume, code for fades, create echos, distort their sounds, change the pitch,  and create a reverb in their sounds.|link:https://earsketch.gatech.edu/earsketch2/#?curriculum=1-4-0&language=python[Effects in EarSketch]
+link:https://earsketch.gatech.edu/yvip/Uploading-Sounds.pdf[Tutorials^]|setEffect() |You will learn how to adjust track volume, code for fades, create echos, distort their sounds, change the pitch,  and create a reverb in their sounds.|<<ch_4#,Effects in EarSketch>>
 
-link:https://earsketch.gatech.edu/earsketch2/#?curriculum=5-1-0&language=python[Every Effect in Detail]
-|  Looping  |You  will learn how to code more efficiently and add repetition to your music.|link:https://earsketch.gatech.edu/earsketch2/#?curriculum=2-4-0&language=python[Looping Tutorials]
+<<ch_28#,Every Effect in Detail>>
+|  Looping  |You  will learn how to code more efficiently and add repetition to your music.|:<<ch_12#,Looping Tutorials>>
 |======================================
 
 ==== Debugging


### PR DESCRIPTION
Issues addressed--

Links open in the same window:
- 35.5 Instructions for creating an account 
- 36.3 Structural: Bank
- 37.1 Looping Tutorials

Broken links:
- 37.1 Effects in EarSketch & Every Effect in Detail

Internal curriculum links:
- 36.6: Student activity "4. Click here" 
- 36.7 "Composing in EarSketch" should be an internal link
- probably others... i'll go through them