### PR TITLE
Update port for local build.

### DIFF
--- a/scripts/local_dev_curriculum_asciidoc_builder.sh
+++ b/scripts/local_dev_curriculum_asciidoc_builder.sh
@@ -16,7 +16,7 @@ fi
 
 ASCIIDOC_DIR=$GIT_REPO/src
 LOCAL_STAGING_DIR=$GIT_REPO/curriculum-local/
-ES_HOST="http://localhost:8080"
+ES_HOST="http://localhost:8888"
 
 cd "$GIT_REPO" || exit 1
 echo "Converting curriculum to html with asciidoctor..."


### PR DESCRIPTION
We now use 8888 for local testing, because we have a SoundCloud ID for a
redirect_uri of localhost:8888 (and we can't create a new one for
localhost:8080). This fixes local hosting of curriculum resources, which
was broken by the port change on earsketch-webclient.