### PR TITLE
Fix issue with incorrect setup of audio examples

### DIFF
--- a/scripts/curr_add_html_features.py
+++ b/scripts/curr_add_html_features.py
@@ -50,7 +50,10 @@ for ch in chapters:
 
 	# replace the divs with "mp3" contents with an audio tag
 	for el in soup.find_all('div', {'class':'curriculum-mp3'}):
-		el.contents[0] = soup.new_tag('audio', src=base_host_url+'/curriculum/'+el.string, controls='')
+		new_src = base_host_url + '/curriculum/' + el.string
+		new_tag = soup.new_tag('audio', src=new_src, controls='')
+		el.contents = []
+		el.append(new_tag)
 
 	# fix legacy audio paths
 	for el in soup.find_all('audio', src=lambda x: x.startswith('./audioMedia/')):


### PR DESCRIPTION
This fixes a breaking change from BeautifulSoup4 that disallows setting the element `contents[]` to raw text representing a new html tag. The correct way to add a new child element to a tag is to use `el.append()`.

I believe this change occurred in v4.11.2 or newer. Recent changes to the project include new ways of handling `.string()` and `.get_text()`.