### PR TITLE
Fix white screen on quiz page

### DIFF
--- a/src/locales/en/v1/musical-repetition.adoc
+++ b/src/locales/en/v1/musical-repetition.adoc
@@ -364,7 +364,7 @@ Notice that inside our `chordProg()` function we are using an incrementing techn
 
 [question]
 --
-_____________ refers to repeated sections of music.
+Which term refers to repeated sections of music?
 [answers]
 * Repetition
 * Contrast


### PR DESCRIPTION
The underscore characters are translated into nested `<em>` tags that crash react.

```html
<p><em><em></em><em></em></em><em>_</em> refers to repeated sections of music.</p>
```

```
Uncaught TypeError: Failed to execute 'replaceChild' on 'Node': parameter 1 is not of type 'Node'.
```

Fixes GTCMT/earsketch#3238.