### PR TITLE
Improve error docs

### DIFF
--- a/src/locales/en/v1/every-error-explained-in-detail.adoc
+++ b/src/locales/en/v1/every-error-explained-in-detail.adoc
@@ -2,8 +2,23 @@
 == Every Error Explained in Detail
 :nofooter:
 
-[[importerror]]
-=== Import Error
+[[othererrors]]
+=== Overview
+
+An error is a mistake in the code that prevents the program from running.
+
+Check the console for details and the line number. In some cases you may need to fix _the preceding line_ to resolve the error.
+
+Guidance on addressing the most common errors is given in the next sections.
+
+[role="curriculum-python"]
+See the official https://docs.python.org/3/library/exceptions.html#concrete-exceptions[Python documentation^] for a full list of errors.
+
+[role="curriculum-javascript"]
+See the official https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors[MDN documentation^] for a full list of errors in JavaScript.
+
+[[modulenotfounderror]]
+=== ModuleNotFoundError
 
 //Python only
 
@@ -148,6 +163,8 @@ include::code-examples/every-error-explained-in-detail-index-error-correction.js
 
 [role="curriculum-python"]
 *Description:* A name error occurs when a program tries to use a variable or call a function that was never defined, most often due to a typo.
+
+Often there is a missing `from earsketch import *` statement at the top of the script.
 
 [role="curriculum-javascript"]
 *Description:* A name error occurs when a program tries to use a variable or call a function that was never defined, most often due to a typo. JavaScript specifically refers to this type of error as a reference error.

--- a/src/locales/en/v1/every-error-explained-in-detail.adoc
+++ b/src/locales/en/v1/every-error-explained-in-detail.adoc
@@ -23,10 +23,10 @@ See the official https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 //Python only
 
 [role="curriculum-python"]
-*Console message:* ImportError: The appropriate packages cannot be found or imported.
+*Console message:* ModuleNotFoundError: No module named 'missing_module_name'
 
 [role="curriculum-python"]
-*Description:* An import error occurs when a program fails to load the module given in a `from...import` statement, like `from module import *`. This could be due to a misspelling, or maybe the module to be imported does not exist.
+*Description:* A ModuleNotFoundError occurs when a program fails to load the module given in a `from...import` statement, like `from module import *`. This could be due to a misspelling, or maybe the module to be imported does not exist.
 
 [role="curriculum-python"]
 *Example:* Although the snippet below shows the word "EarSketch" with its usual styling, Python modules are specified in all lowercase.
@@ -54,7 +54,7 @@ include::code-examples/every-error-explained-in-detail-import-error-correction.p
 *Solution:* Check your `from...import` statements at the top of your script for typos and letter case.
 
 [role="curriculum-javascript"]
-Import errors do not occur in JavaScript. Open a Python script for an explanation of this error type, or move on to <<every-error-explained-in-detail#indexerror,index errors>>.
+ModuleNotFoundErrors do not occur in JavaScript. Open a Python script for an explanation of this error type, or move on to <<every-error-explained-in-detail#othererrors>>.
 
 [[indentationerror]]
 === Indentation Error

--- a/src/locales/en/v1/every-error-explained-in-detail.adoc
+++ b/src/locales/en/v1/every-error-explained-in-detail.adoc
@@ -5,7 +5,9 @@
 [[othererrors]]
 === Overview
 
-An error is a mistake in the code that prevents the program from running.
+Sometimes programmers make mistakes that cause code to work incorrectly, or not run at all. In programming, coding faults are called *errors*, or *bugs*.
+
+The process of finding and fixing bugs is called *debugging*.
 
 Check the console for details and the line number. In some cases you may need to fix _the preceding line_ to resolve the error.
 

--- a/src/locales/en/v1/every-error-explained-in-detail.adoc
+++ b/src/locales/en/v1/every-error-explained-in-detail.adoc
@@ -17,7 +17,7 @@ Guidance on addressing the most common errors is given in the next sections.
 See the official https://docs.python.org/3/library/exceptions.html#concrete-exceptions[Python documentation^] for a full list of errors.
 
 [role="curriculum-javascript"]
-See the official https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors[MDN documentation^] for a full list of errors in JavaScript.
+See Mozilla's https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors[JavaScript documentation^] for a full list of errors.
 
 [[modulenotfounderror]]
 === ModuleNotFoundError


### PR DESCRIPTION
Handle errors missing from the curriculum with a general error overview page.
Use ModuleNotFoundError to match app behavior on missing `from earsketch import *`.

Companion pr to GTCMT/earsketch-webclient#638.